### PR TITLE
Create a rule to support Jetty config files

### DIFF
--- a/rules/rules-reviewed/azure/jetty/jetty-to-azure-external-resources.windup.xml
+++ b/rules/rules-reviewed/azure/jetty/jetty-to-azure-external-resources.windup.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset id="jetty-to-azure-external-resources"
+         xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            Identify external resources in a Jetty configuration file.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"/>
+        </dependencies>
+        <targetTechnology id="azure-spring-apps"/>
+        <targetTechnology id="azure-appservice"/>
+        <targetTechnology id="azure-aks"/>
+        <targetTechnology id="azure-container-apps"/>
+        <tag>jetty</tag>
+    </metadata>
+    <rules>
+        <rule id="jetty-to-azure-external-resources-01000">
+            <when>
+                <xmlfile matches="/Configure/New" in="jetty-env.xml"/>
+            </when>
+            <perform>
+                <hint title="External resources found in configuration file" category-id="optional" effort="5">
+                    <message>
+                        External resources are injected via Java Naming and Directory Interface (JNDI).
+                        These resources can be:
+
+                        * **Data Sources**: If your application relies on a database, consider using an Azure managed database (e.g. Azure PostgreSQL, Azure MySQL, Azure CosmosDB, etc.). Provision a database instance in Azure and configure the necessary connection string.
+
+                        * **JMS Destinations**: If your application utilizes JMS resources, such as message queues or topics, consider using Azure Service Bus as a messaging service. Create the necessary queues or topics in Azure Service Bus and use the appropriate connection details provided by Azure Service Bus.
+
+                        * **Mail Sessions**: If your application sends emails, consider using Azure Communication Services. It provides a variety of communication capabilities, including sending emails from your application.
+
+                        * **Environment Variables**: If your application is configured through environment variables, consider user Azure App Configuration. It enables you to centrally manage and store application settings and configuration data. When dealing with secrets or passwords in your jetty application, it is recommended to use Azure Key Vault to securely store and manage sensitive information.
+
+                        Review the Azure service offerings and choose the appropriate services for your specific needs.
+                    </message>
+                    <link title="Azure services" href="https://azure.microsoft.com/products"/>
+                    <tag>jetty</tag>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules/rules-reviewed/azure/jetty/tests/data/jetty-to-azure-external-resources/jetty-env.xml
+++ b/rules/rules-reviewed/azure/jetty/tests/data/jetty-to-azure-external-resources/jetty-env.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <New id="ds" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/mybd1</Arg>
+        <Arg>
+            <New class="com.mchange.v2.c3p0.ComboPooledDataSource">
+                <Set name="driverClass">com.microsoft.sqlserver.jdbc.SQLServerDriver</Set>
+                <Set name="jdbcUrl">jdbc:jtds:sqlserver://url:1433/mybd1</Set>
+                <Set name="user">xx</Set>
+                <Set name="password">yy</Set>
+            </New>
+        </Arg>
+    </New>
+
+    <New id="ds2" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/mybd2</Arg>
+        <Arg>
+            <New class="com.mchange.v2.c3p0.ComboPooledDataSource">
+                <Set name="driverClass">com.microsoft.sqlserver.jdbc.SQLServerDriver</Set>
+                <Set name="jdbcUrl">jdbc:jtds:sqlserver://url:1433/mybd2</Set>
+                <Set name="user">xx</Set>
+                <Set name="password">yy</Set>
+            </New>
+        </Arg>
+    </New>
+</Configure> 

--- a/rules/rules-reviewed/azure/jetty/tests/data/jetty-to-azure-external-resources/no-jetty-env.xml
+++ b/rules/rules-reviewed/azure/jetty/tests/data/jetty-to-azure-external-resources/no-jetty-env.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <New id="ds" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/mybd1</Arg>
+        <Arg>
+            <New class="com.mchange.v2.c3p0.ComboPooledDataSource">
+                <Set name="driverClass">com.microsoft.sqlserver.jdbc.SQLServerDriver</Set>
+                <Set name="jdbcUrl">jdbc:jtds:sqlserver://url:1433/mybd1</Set>
+                <Set name="user">xx</Set>
+                <Set name="password">yy</Set>
+            </New>
+        </Arg>
+    </New>
+
+    <New id="ds2" class="org.eclipse.jetty.plus.jndi.Resource">
+        <Arg>jdbc/mybd2</Arg>
+        <Arg>
+            <New class="com.mchange.v2.c3p0.ComboPooledDataSource">
+                <Set name="driverClass">com.microsoft.sqlserver.jdbc.SQLServerDriver</Set>
+                <Set name="jdbcUrl">jdbc:jtds:sqlserver://url:1433/mybd2</Set>
+                <Set name="user">xx</Set>
+                <Set name="password">yy</Set>
+            </New>
+        </Arg>
+    </New>
+</Configure> 

--- a/rules/rules-reviewed/azure/jetty/tests/jetty-to-azure-external-resources.windup.test.xml
+++ b/rules/rules-reviewed/azure/jetty/tests/jetty-to-azure-external-resources.windup.test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruletest id="jetty-to-azure-external-resources-test"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/jetty-to-azure-external-resources</testDataPath>
+    <rulePath>../jetty-to-azure-external-resources.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="jetty-to-azure-external-resources-test-01000">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="External resources are injected via Java Naming and Directory Interface \(JNDI\).*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="External resources found in configuration file hint was not found!"/>
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>         


### PR DESCRIPTION
This is based on what we do with the Tomcat configuration file: https://github.com/Azure/appcat-rulesets/blob/main/rules/rules-reviewed/azure/tomcat/tomcat-to-azure-external-resources.windup.xml

Fix #118