### PR TITLE
Bump to WindUp 6.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jboss.windup.rules</groupId>
     <artifactId>windup-rulesets-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.0.Final</version>
 
     <name>Windup Rulesets Parent</name>
     <packaging>pom</packaging>
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.windup>6.3.0-SNAPSHOT</version.windup>
+        <version.windup>6.3.0.Final</version.windup>
     </properties>
 
     <scm>

--- a/rules-themed/pom.xml
+++ b/rules-themed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-themed</artifactId>

--- a/rules-themed/rules-appcat/pom.xml
+++ b/rules-themed/rules-appcat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-themed</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-appcat</artifactId>

--- a/rules-themed/rules-mta/pom.xml
+++ b/rules-themed/rules-mta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-themed</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-mta</artifactId>

--- a/rules-themed/rules-mtr/pom.xml
+++ b/rules-themed/rules-mtr/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-themed</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-mtr</artifactId>

--- a/rules-themed/rules-tackle/pom.xml
+++ b/rules-themed/rules-tackle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-themed</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-tackle</artifactId>

--- a/rules-themed/rules-windup/pom.xml
+++ b/rules-themed/rules-windup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-themed</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets-windup</artifactId>

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.rules</groupId>
         <artifactId>windup-rulesets-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>6.3.0.Final</version>
     </parent>
 
     <artifactId>windup-rulesets</artifactId>


### PR DESCRIPTION
As we agreed, AppCAT is now based on WindUp 6.3.0.Final instead of 6.4.0.SNAPSHOT