### PR TITLE
Create a GitHub workflow to add a triage label

### DIFF
--- a/.github/workflows/issue_label_triage.yml
+++ b/.github/workflows/issue_label_triage.yml
@@ -1,0 +1,21 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["triage"]
+            })


### PR DESCRIPTION
Based on https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues