### PR TITLE
Bump Maven dependency plugin and SLF4J

### DIFF
--- a/rules-themed/pom.xml
+++ b/rules-themed/pom.xml
@@ -22,7 +22,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <id>unpack</id>

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -135,13 +135,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Dependabot created 3 PRs to update some dependencies, but that was still based on WindUp 6.3 SNAPSHOT. This PR is based on 6.3.Final

See:

- https://github.com/Azure/appcat-rulesets/pull/133
- https://github.com/Azure/appcat-rulesets/pull/132
- https://github.com/Azure/appcat-rulesets/pull/131