### PR TITLE
improve windows file path matching pattern

### DIFF
--- a/rules/rules-overridden-azure/os/windows/os-specific.windup.xml
+++ b/rules/rules-overridden-azure/os/windows/os-specific.windup.xml
@@ -47,7 +47,7 @@
                 <matches pattern="(java|properties|jsp|jspf|tag|xml|txt)"/>
             </where>
             <where param="pattern">
-                <matches pattern="(\W|\s|^)(?:[a-zA-Z]\:|\\\\[\w\s\.]+)([\\\/][^\n\t]+)+"/>
+                <matches pattern="(\W|\s|^)([a-zA-Z]\:|\\\\(\w+\.?)+)([\\\/][^\n\t]+)+"/>
             </where>
         </rule>
         <rule id="os-specific-00002">

--- a/rules/rules-reviewed/os/windows/os-specific.windup.xml
+++ b/rules/rules-reviewed/os/windows/os-specific.windup.xml
@@ -28,7 +28,7 @@
                 <matches pattern="(java|properties|jsp|jspf|tag|xml|txt)" />
             </where>
             <where param="pattern">
-                <matches pattern="[A-z]:([\\][^\n\t]+)+|(\\\\([^\\\,\n\t]+)\\\S+)+" />
+                <matches pattern="(\W|\s|^)([a-zA-Z]\:|\\\\(\w+\.?)+)([\\\/][^\n\t]+)+"/>
             </where>
         </rule>
         <rule id="os-specific-00002">

--- a/rules/rules-reviewed/os/windows/tests/data/test.properties
+++ b/rules/rules-reviewed/os/windows/tests/data/test.properties
@@ -1,3 +1,4 @@
 path=c:\Program Files\Apps
 log=D:\logs
 remoteServer=\\hungryserver\u0000
+regexpattern=^(\\d+)x(\\d+)$


### PR DESCRIPTION
What will be mathced:
1. Windows local file path. e.g., C:\Projects\apilibrary\text.txt, D:\\FY2018
2. UNC path. e.g., \\\server.domain.com\share\path\file

What will not be matched: 
Regex patterns. e.g.,  \\d+)x(\\d+)$