### PR TITLE
Improve local host rule

### DIFF
--- a/rules/rules-reviewed/cloud-readiness/localhost.windup.xml
+++ b/rules/rules-reviewed/cloud-readiness/localhost.windup.xml
@@ -6,14 +6,28 @@
             This is a ruleset for check if localhost used in app
         </description>
         <dependencies>
-            <addon id="org.jboss.windup.rules,windup-rules-javaee,2.4.0.Final" />
-            <addon id="org.jboss.windup.rules,windup-rules-java,2.4.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <!-- version ranges applied to from and to technologies -->
         <targetTechnology id="cloud-readiness" />
         <tag>localhost</tag>
     </metadata>
     <rules>
+        <rule id="localhost-java-00001">
+            <when>
+                <javaclass references="java.net.{class}({*})" matchesSource="{*}localhost{*}"/>
+            </when>
+            <perform>
+                <hint title="Local Host Calls" effort="7" category-id="mandatory">
+                    <message>The app is trying to access local resource, please try to migrate the resource to cloud</message>
+                    <tag>localhost</tag>
+                </hint>
+            </perform>
+            <where param="class">
+                <matches pattern="(URL|URI)" />
+            </where>
+        </rule>
         <rule id="localhost-http-00001">
             <when>
                 <filecontent filename="{*}.{extensions}" pattern="{pattern}" />
@@ -25,7 +39,7 @@
                 </hint>
             </perform>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|yaml)" />
+                <matches pattern="(properties|jsp|jspf|tag|xml|txt|yaml)" />
             </where>
             <where param="pattern">
                 <matches pattern="http(s)?://((localhost)|(127\.0\.0\.1))+(:[0-9]+)?(/.*)?" />
@@ -42,7 +56,7 @@
                 </hint>
             </perform>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|yaml)" />
+                <matches pattern="(properties|jsp|jspf|tag|xml|txt|yaml)" />
             </where>
             <where param="pattern">
                 <matches pattern="jdbc:([a-z0-9-]+)://(localhost|127\.0\.0\.1)(:[0-9]+)?" />
@@ -59,7 +73,7 @@
                 </hint>
             </perform>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|yaml)" />
+                <matches pattern="(properties|jsp|jspf|tag|xml|txt|yaml)" />
             </where>
             <where param="pattern">
                 <matches pattern="ws(s)?://((localhost)|(127\.0\.0\.1))+(:[0-9]+)?(/.*)?" />

--- a/rules/rules-reviewed/cloud-readiness/tests/localhost.windup.test.xml
+++ b/rules/rules-reviewed/cloud-readiness/tests/localhost.windup.test.xml
@@ -5,18 +5,6 @@
     <rulePath>../localhost.windup.xml</rulePath>
     <ruleset>
         <rules>
-            <rule id="localhost-java-test-00001">
-                    <when>
-                        <not>
-                            <iterable-filter size="1">
-                                <hint-exists message="The app is trying to access local resource, please try" />
-                            </iterable-filter>
-                        </not>
-                    </when>
-                    <perform>
-                        <fail message="localhost java uri/url usage was not found" />
-                    </perform>
-                </rule>
             <rule id="localhost-http-test-00001">
                 <when>
                     <not>

--- a/rules/rules-reviewed/cloud-readiness/tests/localhost.windup.test.xml
+++ b/rules/rules-reviewed/cloud-readiness/tests/localhost.windup.test.xml
@@ -5,6 +5,18 @@
     <rulePath>../localhost.windup.xml</rulePath>
     <ruleset>
         <rules>
+            <rule id="localhost-java-test-00001">
+                    <when>
+                        <not>
+                            <iterable-filter size="1">
+                                <hint-exists message="The app is trying to access local resource, please try" />
+                            </iterable-filter>
+                        </not>
+                    </when>
+                    <perform>
+                        <fail message="localhost java uri/url usage was not found" />
+                    </perform>
+                </rule>
             <rule id="localhost-http-test-00001">
                 <when>
                     <not>


### PR DESCRIPTION
To avoid false positives in java comments, detect local host in java file by finding local host in java uri/url  instead of finding file content pattern.